### PR TITLE
Use Blob URL to allow bigger exports

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -690,20 +690,12 @@ function registerClickHandlers() {
         if (csv == null) {
           return;
         }
-        let hiddenElement = document.createElement('a');
-        hiddenElement.href = 'data:text/csv;charset=utf-8,' + encodeURI(csv);
-        hiddenElement.target = '_blank';
-        hiddenElement.download = 'trips.csv';
-        hiddenElement.click();
+        downloadFile('trips.csv', csv);
         alert("Note: Fields that are JSON objects are base64 encoded");
 
       } else if (value === "json") {
         let json = JSON.stringify(trips);
-        let hiddenElement = document.createElement('a');
-        hiddenElement.href = 'data:text/json;charset=utf-8,' + encodeURI(json);
-        hiddenElement.target = '_blank';
-        hiddenElement.download = 'trips.json';
-        hiddenElement.click();
+        downloadFile('trips.json', json);
       }
     }
   });

--- a/js/mainEats.js
+++ b/js/mainEats.js
@@ -224,20 +224,12 @@ function registerClickHandlers() {
         if (csv == null) {
           return;
         }
-        let hiddenElement = document.createElement('a');
-        hiddenElement.href = 'data:text/csv;charset=utf-8,' + encodeURI(csv);
-        hiddenElement.target = '_blank';
-        hiddenElement.download = 'orders.csv';
-        hiddenElement.click();
+        downloadFile('orders.csv', csv);
         alert("Note: Fields that are JSON objects are base64 encoded");
 
       } else if (value === "json") {
         let json = JSON.stringify(orders);
-        let hiddenElement = document.createElement('a');
-        hiddenElement.href = 'data:text/json;charset=utf-8,' + encodeURI(json);
-        hiddenElement.target = '_blank';
-        hiddenElement.download = 'orders.json';
-        hiddenElement.click();
+        downloadFile('orders.json', json);
       }
     }
   });

--- a/js/utils.js
+++ b/js/utils.js
@@ -96,3 +96,16 @@ function secondsToMinutes(time) {
   ret += "" + secs + "s";
   return ret;
 }
+
+function downloadFile(filename, contents) {
+  const blob = new Blob([contents], {type: 'octet/stream'});
+  const url = URL.createObjectURL(blob);
+  const hiddenElement = document.createElement('a');
+  hiddenElement.href = url;
+  hiddenElement.target = '_blank';
+  hiddenElement.download = filename;
+  hiddenElement.click();
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  });
+}


### PR DESCRIPTION
Hi, thanks for making this extension! 🙌

I've been using it a long time and I always struggle with exports and need to do them manually in devtools because they are too big. Chrome has a limit for the URL length and this also applies to the download link you are creating with the base64 contents of files. 

My profile has a few hundreds of rides and it already goes over the limit and the downloaded file is just cut off mid-JSON, leading to an incomplete and corrupted file. 

This PR introduces a Blob object which gets around the limit for download because its generated URL is of a static length. Blobs are [widely supported now](https://caniuse.com/#feat=bloburls).