### PR TITLE
Add full export option

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -679,7 +679,8 @@ function registerClickHandlers() {
       input: 'radio',
       inputOptions: {
         csv: "CSV",
-        json: "JSON"
+        json: "JSON",
+        full: "JSON (Full Details)",
       }
     });
     if (value) {
@@ -696,6 +697,14 @@ function registerClickHandlers() {
       } else if (value === "json") {
         let json = JSON.stringify(trips);
         downloadFile('trips.json', json);
+      } else if (value === "full") {
+        let json = JSON.stringify({
+          trips,
+          cities: [...global.cities.values()],
+          drivers: [...global.drivers.values()],
+          payment: [...global.payment.values()],
+        });
+        downloadFile('trips-full.json', json);
       }
     }
   });


### PR DESCRIPTION
This is more of a feature request than a fix and I'm happy to keep using it from my branch if it doesn't make a global appeal. 

I'm using your extension as a source for further processing of my data (since it's probably the most convenient way to get data from _certain companies_) and in the `trips.json`, I'm missing some entities that are only included as their ids. This bring all entities to the export, essentially exporting everything inside the `global` variable.

Would this make sense for inclusion? Or do you have any other idea how to make these available? 